### PR TITLE
[UPDATE] mf-timekeeper can backward with webpack

### DIFF
--- a/mf-timekeeper/src/mf-timekeeper.test.ts
+++ b/mf-timekeeper/src/mf-timekeeper.test.ts
@@ -1,21 +1,165 @@
 import { describe, it, expect, vi } from 'vitest';
-import getRemoteEntryUrl from './mf-timekeeper';
-import { getCurrentTimestamp } from './utils';
+import { getRemoteEntryUrl } from './mf-timekeeper';
+import { afterEach } from 'node:test';
 
-vi.mock('./utils', () => ({
-  getCurrentTimestamp: vi.fn().mockReturnValue("20230421_120000")
-}));
+// Mock the global fetch function
+global.fetch = vi.fn();
+
+// Function to create a fetch response with a delay
+const createFetchResponse = (urlDataMap, delay = 0) => {
+  return (url) => {
+    return new Promise<Response>((resolve) => {
+      setTimeout(() => {
+        const data = urlDataMap[url] || {}; // Get data for the URL or return an empty object if not found
+        resolve(new Response(
+          JSON.stringify(data),
+          {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' }
+          }
+        ));
+      }, delay);
+    });
+  };
+};
 
 describe('getRemoteEntryUrl', () => {
-  it('returns a correctly formatted URL', async () => {
-    const url = await getRemoteEntryUrl('localhost:4174', 'remoteApp');
-    expect(url).toBe('http://localhost:4174/assets/20230421_120000_remoteAppremoteEntry.js');
-  });
 
-  it('should handle errors in timestamp generation', async () => {
-    vi.mocked(getCurrentTimestamp).mockImplementationOnce(() => {
-      throw new Error('Failed to generate timestamp');
-    });
-    await expect(getRemoteEntryUrl('localhost:4174', 'remoteApp')).rejects.toThrow('Failed to generate timestamp');
-  });
+  describe('on vite bundle', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    })
+
+    it('should be return remoteEntry from base url with version number', async () => {
+      const urlDataMap = {
+        'https://api.myendpoint.com?token=1234&currentHost=myCurrentHost&remoteName=myRemoteName': { version: '2024_06_21__09_02', name: "myRemoteName", remoteURL: "https://cdn.mycdn.com/cdn-mf/" },
+      };
+
+      vi.mocked(fetch).mockImplementation(await createFetchResponse(urlDataMap, 0))
+
+      const remoteEntry = getRemoteEntryUrl({
+        remoteName: 'myRemoteName',
+        currentHost: 'myCurrentHost',
+        apiUrl: 'https://api.myendpoint.com?token=1234',
+        baseUrl: 'https://cdn.mycdn.com/cdn-mf',
+        fallbackUrl: 'https://cdn.mycdn.com/cdn-mf/remoteEntry-deprecated.js'
+      })
+
+      const remoteEntryFunction = new Function(`return ${remoteEntry}`);
+      const remoteEntryResult = await remoteEntryFunction();
+      expect(remoteEntryResult).toBe("https://cdn.mycdn.com/cdn-mf/2024_06_21__09_02.remoteEntry.js")
+    })
+
+    it('should be return fallback url when api is very slow', async () => {
+      const urlDataMap = {
+        'https://api.myendpoint.com?token=1234&currentHost=myCurrentHost&remoteName=myRemoteName': { version: '2024_06_21__09_02', name: "myRemoteName", remoteURL: "https://cdn.mycdn.com/cdn-mf/" },
+      };
+
+      vi.mocked(fetch).mockImplementation(await createFetchResponse(urlDataMap, 10000))
+
+      const remoteEntry = getRemoteEntryUrl({
+        remoteName: 'myRemoteName',
+        currentHost: 'myCurrentHost',
+        apiUrl: 'https://api.myendpoint.com?token=1234',
+        baseUrl: 'https://cdn.mycdn.com/cdn-mf',
+        fallbackUrl: 'https://cdn.mycdn.com/cdn-mf/remoteEntry-deprecated.js',
+        timeout: 100
+      })
+
+      const remoteEntryFunction = new Function(`return ${remoteEntry}`);
+      const remoteEntryResult = await remoteEntryFunction();
+      expect(remoteEntryResult).contain(`https://cdn.mycdn.com/cdn-mf/remoteEntry-deprecated.js`)
+    })
+
+    it('should be return fallback url when api is error', async () => {
+      const urlDataMap = {
+        'https://api.myendpoint.com?token=1234&currentHost=myCurrentHost&remoteName=myRemoteName': { something_wrong: 'something_wrong' },
+      };
+
+      vi.mocked(fetch).mockImplementation(await createFetchResponse(urlDataMap, 10000))
+
+      const remoteEntry = getRemoteEntryUrl({
+        remoteName: 'myRemoteName',
+        currentHost: 'myCurrentHost',
+        apiUrl: 'https://api.myendpoint.com?token=1234',
+        baseUrl: 'https://cdn.mycdn.com/cdn-mf',
+        fallbackUrl: 'https://cdn.mycdn.com/cdn-mf/remoteEntry-deprecated.js',
+        timeout: 100
+      })
+
+      const remoteEntryFunction = new Function(`return ${remoteEntry}`);
+      const remoteEntryResult = await remoteEntryFunction();
+      expect(remoteEntryResult).contain(`https://cdn.mycdn.com/cdn-mf/remoteEntry-deprecated.js`)
+    })
+  })
+
+  describe('on webpack bundle', () => {
+    it('should be return remoteEntry from base url with version number', async () => {
+      const urlDataMap = {
+        'https://api.myendpoint.com?token=1234&currentHost=myCurrentHost&remoteName=myRemoteName': { version: '2024_06_21__09_02', name: "myRemoteName", remoteURL: "https://cdn.mycdn.com/cdn-mf/" },
+        'https://cdn.mycdn.com/cdn-mf/2024_06_21__09_02.remoteEntry.js': `var myRemoteName;(()=>{"use strict"....`,
+      };
+
+      vi.mocked(fetch).mockImplementation(await createFetchResponse(urlDataMap, 0))
+
+      const remoteEntry = getRemoteEntryUrl({
+        remoteName: 'myRemoteName',
+        currentHost: 'myCurrentHost',
+        apiUrl: 'https://api.myendpoint.com?token=1234',
+        baseUrl: 'https://cdn.mycdn.com/cdn-mf',
+        fallbackUrl: 'https://cdn.mycdn.com/cdn-mf/remoteEntry-deprecated.js',
+        bundle: "webpack"
+      })
+
+      const remoteEntryFunction = new Function(`return ${remoteEntry}`);
+      const remoteEntryResult = await remoteEntryFunction();
+      expect(remoteEntryResult).toBe("myRemoteName@https://cdn.mycdn.com/cdn-mf/2024_06_21__09_02.remoteEntry.js")
+    })
+
+    it('should be return fallback url when api is very slow', async () => {
+      const urlDataMap = {
+        'https://api.myendpoint.com?token=1234&currentHost=myCurrentHost&remoteName=myRemoteName': { version: '2024_06_21__09_02', name: "myRemoteName", remoteURL: "https://cdn.mycdn.com/cdn-mf/" },
+        'https://cdn.mycdn.com/cdn-mf/2024_06_21__09_02.remoteEntry.js': `var myRemoteName;(()=>{"use strict"....`,
+      };
+
+      vi.mocked(fetch).mockImplementation(await createFetchResponse(urlDataMap, 10000))
+
+      const remoteEntry = getRemoteEntryUrl({
+        remoteName: 'myRemoteName',
+        currentHost: 'myCurrentHost',
+        apiUrl: 'https://api.myendpoint.com?token=1234',
+        baseUrl: 'https://cdn.mycdn.com/cdn-mf',
+        fallbackUrl: 'https://cdn.mycdn.com/cdn-mf/remoteEntry-deprecated.js',
+        timeout: 100,
+        bundle: "webpack"
+      })
+
+      const remoteEntryFunction = new Function(`return ${remoteEntry}`);
+      const remoteEntryResult = await remoteEntryFunction();
+      expect(remoteEntryResult).contain("myRemoteName@https://cdn.mycdn.com/cdn-mf/remoteEntry-deprecated.js")
+    })
+
+    it('should be return fallback url when api is error', async () => {
+      const urlDataMap = {
+        'https://api.myendpoint.com?token=1234&currentHost=myCurrentHost&remoteName=myRemoteName': { something_wrong: 'something_wrong' },
+        'https://cdn.mycdn.com/cdn-mf/2024_06_21__09_02.remoteEntry.js': `var myRemoteName;(()=>{"use strict"....`,
+      };
+
+      vi.mocked(fetch).mockImplementation(await createFetchResponse(urlDataMap, 10000))
+
+      const remoteEntry = getRemoteEntryUrl({
+        remoteName: 'myRemoteName',
+        currentHost: 'myCurrentHost',
+        apiUrl: 'https://api.myendpoint.com?token=1234',
+        baseUrl: 'https://cdn.mycdn.com/cdn-mf',
+        fallbackUrl: 'https://cdn.mycdn.com/cdn-mf/remoteEntry-deprecated.js',
+        timeout: 100,
+        bundle: "webpack"
+      })
+
+      const remoteEntryFunction = new Function(`return ${remoteEntry}`);
+      const remoteEntryResult = await remoteEntryFunction();
+      expect(remoteEntryResult).contain("myRemoteName@https://cdn.mycdn.com/cdn-mf/remoteEntry-deprecated.js")
+    })
+  })
 });

--- a/mf-timekeeper/src/mf-timekeeper.ts
+++ b/mf-timekeeper/src/mf-timekeeper.ts
@@ -1,15 +1,84 @@
-export function getRemoteEntryUrl(baseUrl: string, apiUrl: string, fallbackUrl: string, timeout = 5000): string {
-    return `
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), ${timeout});
+/**
+* Options for getting the remote entry URL.
+*/
+export interface GetRemoteEntryOptions {
+    /** The name of the remote module. */
+    remoteName: string;
+    /** The current host name. */
+    currentHost: string;
+    /** The version of the remote module. */
+    version?: string;
+    /** The API URL to fetch the version information. */
+    apiUrl: string;
+    /** The base URL for the remote entry. */
+    baseUrl: string;
+    /** The fallback URL to use in case of an error. */
+    fallbackUrl: string;
+    /** The timeout duration in milliseconds. Optional, defaults to 3000. */
+    timeout?: number;
+    /** The build tool used, either 'vite' or 'webpack'. Optional, defaults to 'vite'. */
+    bundle?: "vite" | "webpack";
+}
+/**
+ * Generates the remote entry URL based on the provided options.
+ * 
+ * @param options - The options for generating the remote entry URL.
+ * @returns The JavaScript code as a string to fetch the remote entry URL.
+ */
+export function getRemoteEntryUrl(options: GetRemoteEntryOptions): string {
+    const { 
+        remoteName,  // The name of the remote module.
+        currentHost,  // The current host name.
+        version,  // The version of the remote module.
+        apiUrl,  // The API URL to fetch the version information.
+        baseUrl,  // The base URL for the remote entry.
+        fallbackUrl,  // The fallback URL to use in case of an error.
+        timeout = 3000,  // The timeout duration in milliseconds. Defaults to 3000 if not provided.
+        bundle = "vite"  // The build tool used, either 'vite' or 'webpack'. Defaults to 'vite' if not provided.
+    } = options;
 
-    fetch('${apiUrl}')
-        .then(response => response.json())
-        .then(data => \`http://${baseUrl}/\${data.version}_remoteEntry.js\`)
+    if (bundle == "webpack") {
+        return `Promise.race([
+            new Promise((resolve) => {
+                fetch(\`${apiUrl}&currentHost=${currentHost}&remoteName=${remoteName}\`)
+                .then(response => response.json())
+                .then(data => {
+                    const version = data.version;
+                    const fileName = \`${baseUrl}/\${version}.remoteEntry.js\`;
+
+                    return fetch(fileName).then(response => response.text()).then(fileContent => {
+                        console.log("fileContent", fileContent);
+                        const variableNameMatch = fileContent.match(/var\\s+(\\w+)\\s*;/);
+                        if (variableNameMatch) {
+                            const variableName = variableNameMatch[1];
+                            resolve(\`\${variableName}@${baseUrl}/\${version}.remoteEntry.js\`);
+                        } else {
+                            throw new Error('Variable name not found in the file content.');
+                        }
+                    });
+                })
+            }),
+            new Promise((resolve, reject) => 
+                setTimeout(() => resolve(\`${remoteName}@${fallbackUrl}?t=\${new Date().getTime()}\`), ${timeout})
+            )
+        ])
         .catch(error => {
-            console.error('Error fetching version:', error);
-            return 'http://${fallbackUrl}?/\${new Date().getTime()}';
-        })`;
+            resolve(\`${remoteName}@${fallbackUrl}?t=\${new Date().getTime()}\`);
+        });`;
+    }
+
+    return `Promise.race([
+                fetch(\`${apiUrl}&currentHost=${currentHost}&remoteName=${remoteName}\`).then(response => {
+                    if (!response.ok) throw new Error('Network response was not ok.');
+                    return response.json();
+                }).then(data => \`${baseUrl}/\${data.version}.remoteEntry.js\`),
+                new Promise((resolve, reject) => 
+                    setTimeout(() => resolve(\`${fallbackUrl}?t=\${new Date().getTime()}\`), ${timeout})
+                )
+            ])
+            .catch(error => {
+                return \`${fallbackUrl}?t=\${new Date().getTime()}\`;
+            });`;
 }
 
 export async function updateVersion(apiUrl: string, remoteName: string, version: string): Promise<boolean> {


### PR DESCRIPTION
- getRemoteEntryUrl with return entrypoint base on bundle : `vite` or `webpack`
- getRemoteEntryUrl will recieve options: remoteName, apiUrl, baseUrl, etc.
- Test for getRemoteEntryUrl